### PR TITLE
chore(ci): add commitlint-ai config and upgrade node version to 24

### DIFF
--- a/.elsikora/commitlint-ai.config.js
+++ b/.elsikora/commitlint-ai.config.js
@@ -1,0 +1,14 @@
+export default {
+	maxRetries: 3,
+	mode: "auto",
+	model: "claude-opus-4-5",
+	provider: "anthropic",
+	ticket: {
+		missingBranchLintBehavior: "fallback",
+		normalization: "preserve",
+		pattern: "[a-z]{2,}-[0-9]+",
+		patternFlags: "i",
+		source: "auto",
+	},
+	validationMaxRetries: 3,
+};

--- a/.github/workflows/qodana-quality-scan.yml
+++ b/.github/workflows/qodana-quality-scan.yml
@@ -1,7 +1,7 @@
 name: Qodana Quality Scan
 
 env:
-  NODE_VERSION: 20
+  NODE_VERSION: 24
   CHECKOUT_DEPTH: 0
 
 on: push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release And Publish
 
 env:
-  NODE_VERSION: 20
+  NODE_VERSION: 24
 
 on:
   push:

--- a/.github/workflows/snyk-security-scan.yml
+++ b/.github/workflows/snyk-security-scan.yml
@@ -1,7 +1,7 @@
 name: Snyk Security Scan
 
 env:
-  NODE_VERSION: 20
+  NODE_VERSION: 24
   SNYK_GLOBAL_PACKAGES: snyk snyk-to-html
 
 on: push


### PR DESCRIPTION
Add .elsikora/commitlint-ai.config.js with anthropic provider configuration. Update NODE_VERSION from 20 to 24 in qodana-quality-scan, release, and snyk-security-scan workflows.