### PR TITLE
refactor(config): add generic type parameter for factory arguments in…

### DIFF
--- a/src/modules/config/config.module.ts
+++ b/src/modules/config/config.module.ts
@@ -33,7 +33,7 @@ export class ParameterStoreConfigModule {
 	 * @param {IParameterStoreConfigAsyncModuleProperties} properties - The properties for the async module.
 	 * @returns {DynamicModule} - The registered dynamic module.
 	 */
-	public static registerAsync(properties: IParameterStoreConfigAsyncModuleProperties): DynamicModule {
+	public static registerAsync<TFactoryArguments extends Array<unknown> = Array<unknown>>(properties: IParameterStoreConfigAsyncModuleProperties<TFactoryArguments>): DynamicModule {
 		const providers: Array<Provider> = this.createAsyncProviders(properties);
 
 		return {
@@ -50,7 +50,7 @@ export class ParameterStoreConfigModule {
 	 * @returns {Provider} - The created async options provider.
 	 * @private
 	 */
-	private static createAsyncOptionsProvider(properties: IParameterStoreConfigAsyncModuleProperties): Provider {
+	private static createAsyncOptionsProvider<TFactoryArguments extends Array<unknown> = Array<unknown>>(properties: IParameterStoreConfigAsyncModuleProperties<TFactoryArguments>): Provider {
 		if (properties.useFactory) {
 			return {
 				inject: properties.inject ?? [],
@@ -76,7 +76,7 @@ export class ParameterStoreConfigModule {
 	 * @returns {Array<Provider>} An array of Providers for the module configuration.
 	 * @private
 	 */
-	private static createAsyncProviders(properties: IParameterStoreConfigAsyncModuleProperties): Array<Provider> {
+	private static createAsyncProviders<TFactoryArguments extends Array<unknown> = Array<unknown>>(properties: IParameterStoreConfigAsyncModuleProperties<TFactoryArguments>): Array<Provider> {
 		const optionsProvider: Provider = this.createAsyncOptionsProvider(properties);
 
 		const requestProviders: Array<Provider> = [optionsProvider, ParameterStoreConfigParametersProvider, ParameterStoreConfigSSMProvider, ParameterStoreConfigService, ParameterStoreService];

--- a/src/shared/interface/config/async-module-properties.interface.ts
+++ b/src/shared/interface/config/async-module-properties.interface.ts
@@ -7,7 +7,7 @@ import type { IParameterStoreConfigProperties } from "./properties.interface";
  * Interface for asynchronous module configuration properties.
  * Provides different options for asynchronously configuring the Parameter Store module.
  */
-export interface IParameterStoreConfigAsyncModuleProperties extends Pick<ModuleMetadata, "imports"> {
+export interface IParameterStoreConfigAsyncModuleProperties<TFactoryArguments extends Array<unknown> = Array<unknown>> extends Pick<ModuleMetadata, "imports"> {
 	/** Optional array of dependencies to be injected into the factory function or class */
 	inject?: Array<InjectionToken | OptionalFactoryDependency>;
 	/** Optional class that implements IParameterStoreConfigPropertiesFactory to be instantiated */
@@ -15,5 +15,5 @@ export interface IParameterStoreConfigAsyncModuleProperties extends Pick<ModuleM
 	/** Optional existing provider implementing IParameterStoreConfigPropertiesFactory to be used */
 	useExisting?: Type<IParameterStoreConfigPropertiesFactory>;
 	/** Optional factory function that returns configuration properties */
-	useFactory?: (...arguments_: Array<unknown>) => IParameterStoreConfigProperties | Promise<IParameterStoreConfigProperties>;
+	useFactory?: (...arguments_: TFactoryArguments) => IParameterStoreConfigProperties | Promise<IParameterStoreConfigProperties>;
 }


### PR DESCRIPTION
… async module

Added TFactoryArguments generic type parameter to registerAsync, createAsyncOptionsProvider, and createAsyncProviders methods to improve type safety for factory function arguments. Updated IParameterStoreConfigAsyncModuleProperties interface to accept the generic type.